### PR TITLE
Improved readability for jekyll-generated markup

### DIFF
--- a/content-creation.md
+++ b/content-creation.md
@@ -2,27 +2,22 @@
 
 Lavender is currently on `Unity 2019.3.0f3`
 
-We highly suggest using [Unity Hub](https://unity3d.com/get-unity/download) in order to manage your unity installs.
+We highly suggest using [Unity Hub](https://unity3d.com/get-unity/download) in order to manage your unity installs.  
 Simply hit add, scroll to the bottom for beta & alpha versions, select the right one, then hit the checkmarks on
+
 * Linux Mono
 * Android
 
 To create content for Lavender, first we need the Lavender SDK. If you’ve 
-bought the game on Steam, the SDK can be found within the Steam Library of your
- account, search for “Lavender SDK”. Double clicking it will open the folder 
- containing a file named “LavenderSDK.unitypackage”, import this into Unity by 
- double clicking it while Unity is open, or by going to 
- `Assets -> Import Package -> Custom Package` and browsing to the file.
+bought the game on Steam, the SDK can be found within the Steam Library of your account, search for “Lavender SDK”. Double clicking it will open the folder containing a file named “LavenderSDK.unitypackage”.
 
-Note: Make sure to backup your project if upgrading from an older version of 
-Unity and make sure to remove other game SDKs from it as well to ensure 
-compatibility. Project Defaults and Project Layers may fail to be setup in rare 
-cases, to fix this, go to Lavender at the top of the Unity window and press 
-`Setup Project defaults & Setup Layer defaults`
- For all content, we recommend having a proper folder setup for organization 
- purposes, a folder structure example such as “Assets/Avatars/modelname/model.fbx” 
- and a folder for materials, animations, scripts, sounds within each model 
- project is recommended.
+Import this file into Unity by double clicking it while Unity is open, or by going to `Assets -> Import Package -> Custom Package` and browsing to the file. You can also drag-and-drop the unitypackage into the asset browser.
+
+### Notes
+ - Make sure to backup your project if upgrading from an older version of Unity.
+ - Make sure to remove other game SDKs from it as well to ensure compatibility.
+ - Project Defaults and Project Layers may fail to be setup in rare cases. To fix this, go to Lavender at the top of the Unity window and press `Setup Project defaults & Setup Layer defaults`.
+ - For all content, we recommend having a proper folder setup for organization purposes. A folder structure example such as “Assets/Avatars/modelname/model.fbx” and a folder for materials, animations, scripts, sounds within each model project is recommended.
 
 
 ## Create something:

--- a/creating-avatars.md
+++ b/creating-avatars.md
@@ -4,17 +4,20 @@
 
 ## For new creators
 
-Creating Avatars for Lavender requires a rigged character that Unity can use (a Humanoid character or any other Unity Mecanim viable rigged model), if such a model is available, creating an avatar is possible and can be done by first importing the 3d model into Unity by dragging and dropping it into the Project Folder, clicking on the model & then going to Rig, selecting “Humanoid” from the Animation Type then applying settings so the Avatar can be configured, then under Avatar Definition, select “Create From This Model” from the dropdown menu.  
+Creating Avatars for Lavender requires a rigged character that Unity can use (a Humanoid character or any other Unity Mecanim viable rigged model). If such a model is available, creating an avatar is possible and can be done by first importing the 3d model into Unity by dragging and dropping it into the Project Folder, clicking on the model & then going to Rig, selecting “Humanoid” from the Animation Type then applying settings so the Avatar can be configured, then under Avatar Definition, select “Create From This Model” from the dropdown menu.
+
 This will switch Unity into the Rig Mapping mode, check if every bone is correctly assigned (If everything is green, things are likely good to go - depending on the character), scroll down on the very left side and press Apply/Done, assuming the model has been correctly configured, drag the model into the scene/hierarchy window and everything is good to go for the next step.
 
 
 ### Materials
-Setting up Materials is required for the Avatar model to shade properly, if the model has already had materials setup in a 3d modelling suite such as Blender, Maya, 3DSMax, then it is possible to extract those materials. This is done by going to the same page as the Model Setup, clicking on the Materials tab and clicking on “Extract Materials”, choose a folder within the models Project Folder. In the material folder, select each material one by one and assign the texture(s) corresponding to the Material, if everything is setup correctly, you should see the changes reflected within the scene, assuming that the Model is present in the current scene.
+Setting up Materials is required for the Avatar model to shade properly. If the model has already had materials setup in a 3d modelling suite such as Blender, Maya, 3DSMax, then it is possible to extract those materials.
+
+This is done by going to the same page as the Model Setup, clicking on the Materials tab and clicking on “Extract Materials”. Choose a folder within the models Project Folder. In the material folder, select each material one by one and assign the texture(s) corresponding to the Material. If everything is setup correctly, you should see the changes reflected within the scene, assuming that the Model is present in the current scene.
 
 **Note:** If the Standard shader material setup does not look satisfactory for an Anime/Cartoon style character, you may download a open-source toon shader. Here are two that should work with the latest version of Unity:
 
-[NoeNoe](https://github.com/HugoZink/NoeNoeShaderEdits)
-[Poiyomi](https://github.com/poiyomi/PoiyomiToonShader)
+ - [NoeNoe](https://github.com/HugoZink/NoeNoeShaderEdits)
+ - [Poiyomi](https://github.com/poiyomi/PoiyomiToonShader)
 
 For the new Unity Scriptable Render Pipelines such as HDRP/URP, a Shader Graph shader will be linked here on a later date.
 

--- a/creating-avatars.md
+++ b/creating-avatars.md
@@ -4,39 +4,41 @@
 
 ## For new creators
 
-Creating Avatars for Lavender requires a rigged character that Unity can use (a Humanoid character or any other Unity Mecanim viable rigged model), if such a model is available, creating an avatar is possible and can be done by first importing the 3d model into Unity by dragging and dropping it into the Project Folder, clicking on the model & then going to Rig, selecting “Humanoid” from the Animation Type then applying settings so the Avatar can be configured, then under Avatar Definition, select “Create From This Model” from the dropdown menu.
+Creating Avatars for Lavender requires a rigged character that Unity can use (a Humanoid character or any other Unity Mecanim viable rigged model), if such a model is available, creating an avatar is possible and can be done by first importing the 3d model into Unity by dragging and dropping it into the Project Folder, clicking on the model & then going to Rig, selecting “Humanoid” from the Animation Type then applying settings so the Avatar can be configured, then under Avatar Definition, select “Create From This Model” from the dropdown menu.  
 This will switch Unity into the Rig Mapping mode, check if every bone is correctly assigned (If everything is green, things are likely good to go - depending on the character), scroll down on the very left side and press Apply/Done, assuming the model has been correctly configured, drag the model into the scene/hierarchy window and everything is good to go for the next step.
 
 
 ### Materials
 Setting up Materials is required for the Avatar model to shade properly, if the model has already had materials setup in a 3d modelling suite such as Blender, Maya, 3DSMax, then it is possible to extract those materials. This is done by going to the same page as the Model Setup, clicking on the Materials tab and clicking on “Extract Materials”, choose a folder within the models Project Folder. In the material folder, select each material one by one and assign the texture(s) corresponding to the Material, if everything is setup correctly, you should see the changes reflected within the scene, assuming that the Model is present in the current scene.
-Note: If the Standard shader material setup does not look satisfactory for an Anime/Cartoon style character, you may download a open-source toon shader. Here are two that should work with the latest version of Unity: 
-[NoeNoe](https://github.com/HugoZink/NoeNoeShaderEdits) 
-[Poiyomi](https://github.com/poiyomi/PoiyomiToonShader) 
+
+**Note:** If the Standard shader material setup does not look satisfactory for an Anime/Cartoon style character, you may download a open-source toon shader. Here are two that should work with the latest version of Unity:
+
+[NoeNoe](https://github.com/HugoZink/NoeNoeShaderEdits)
+[Poiyomi](https://github.com/poiyomi/PoiyomiToonShader)
+
 For the new Unity Scriptable Render Pipelines such as HDRP/URP, a Shader Graph shader will be linked here on a later date.
+
 ### Avatar Setup
-This is the final step within Unity, to setup your Avatar for Lavender, click on your model, on the very right side click “Add Component” and search for “Avatar” and press Enter. This should add the Lavender SDK Avatar component to the character, this is a required component. Within this Script, we have to setup the View Offset and Mouth Offset and assign our Visemes, once this is done we can hit Quick Build Avatar to create it. 
-The View Offset is used as the point of view position of our character, usually this point is positioned in between our characters eyes with a depth that matches this.
+This is the final step within Unity, to setup your Avatar for Lavender, click on your model, on the very right side click “Add Component” and search for “Avatar” and press Enter. This should add the Lavender SDK Avatar component to the character, this is a required component. Within this Script, we have to setup the View Offset and Mouth Offset and assign our Visemes, once this is done we can hit Quick Build Avatar to create it.  
+The View Offset is used as the point of view position of our character, usually this point is positioned in between our characters eyes with a depth that matches this.  
 The Mouth Offset is used as the audio position of our character, this is from where a sound will be heard from when a player talks.
+
 ### Avatar Head
 In most cases, the Hide Action does not need to be changed, only in certain cases such as when our character has their face or head model separated from the body we may need to use Toggle Mesh instead of Scale Head Down and move the model into the selection field, advanced users are also able to use the Shape Key function.
-Visemes
-If our character in the scene has Visemes (pre-made mouth shapes required for lip sync), all we have to do is expand the prefab from the Unity Hierarchy found on the left side of the Editor and drag the character’s main mesh into the Viseme field, often this is called Body. If you have used a Blender addon called CATS to create these shapes, Lavender SDK script can auto-assign the Visemes for us. (Auto Assign by close enough name)
+
+#### Visemes
+If our character in the scene has Visemes (pre-made mouth shapes required for lip sync), all we have to do is expand the prefab from the Unity Hierarchy found on the left side of the Editor and drag the character’s main mesh into the Viseme field, often this is called Body. If you have used a Blender addon called CATS to create these shapes, Lavender SDK script can auto-assign the Visemes for us. (Auto Assign by close enough name).
+
 If everything is correct, hit Quick Build Avatar, the file will be in the root of our Project Folder. We’re done!
 
-Now we just need to upload to our account on the website:
-[Uploading Content](./uploading-content.md)
-
+[Now we just need to upload to our account on the website](./uploading-content.md)
 
 ## For Advanced Users
 Import your model, configure the Rig as Humanoid, setup materials, add the Lavender SDK “Avatar” component to the rigged model in your scene, adjust your viewball, mouth offset using either the input field or gizmos, assign/auto-assign Oculus Visemes and press Quick Build Avatar.
 
-```
-Note: If the filesize of the built avatar is larger than expected, check “Legacy Blend Shape Normals” in the model import options.
-```
+**Note:** If the filesize of the built avatar is larger than expected, check “Legacy Blend Shape Normals” in the model import options.
 
-Now we just need to upload to our account on the website:
-[Uploading Content](./uploading-content.md)
+[With that out of the way, you can upload the avatar](./uploading-content.md)
 
 
 

--- a/creating-worlds.md
+++ b/creating-worlds.md
@@ -4,8 +4,7 @@ Creating Worlds for Lavender is simple, all you need is to have a GameObject in 
 
 There’s a few ways to do this, one of them is to create a new object within the scene (Empty GameObject) and attach the “World” component to it, this is where players will start when entering your World. To see the starting point of players much easier in the editor window it is possible to use a 3D GameObject such as a 3D Cube to position the World component better and then later remove physics and mesh renderer/filter from it to prevent spawning issues. Make sure to save the scene.
 
-When you’re ready to build your scene into a Lavender compatible World, all that is left to do is to create a new Lavender World bundle, this is done right clicking on an empty space in the Project Browser window and going to `Create -> Lavender -> World`
+When you’re ready to build your scene into a Lavender compatible World, all that is left to do is to create a new Lavender World bundle, this is done right clicking on an empty space in the Project Browser window and going to `Create -> Lavender -> World`.  
 Fill out the name field of the World, this will be the name of the file on disk, drag the scene that was saved earlier into the scene field and press Package/Build and we’re done!
 
-Now take that .world file to the website:
-[Uploading Content](./uploading-content.md)
+[Now take that .world file to the website](./uploading-content.md)

--- a/full-body-binding.md
+++ b/full-body-binding.md
@@ -1,17 +1,14 @@
-To enable and use full body binding, you will first need to setup your trackers 'roles' in steam Manage Trackers interface.
-You will need one tracker set as waist, one set as left foot, and one as right.
+To enable and use full body binding, you will first need to setup your trackers 'roles' in steam Manage Trackers interface.  
+You will need one tracker set as waist, one set as left foot, and one as right.  
 In the future we will be supporting more tracking points, but maybe not though this mechanism.
 
-After roles are set, you will see all three trackers ingame floating where you expect.
-Once trackers are floating and present ingame, you simply switch to any avatar to start the bind process. 
-Your model will load in after downloading, spawn in a t-pose. 
-You then move into place to match the models waist and feet location.
-After in place pull the trigger on either controller to bind from current offsets.
+After roles are set, you will see all three trackers ingame floating where you expect.  
+Once trackers are floating and present ingame, you simply switch to any avatar to start the bind process.  
+Your model will load in after downloading, spawn in a t-pose.  
+You then move into place to match the models waist and feet location.  
+After in place pull the trigger on either controller to bind from current offsets.  
 You can quickly rebind at any time by respawning the same model.
 
+**Note:** currently there is a bug that places model in the ground slightly when on a server. **This will be fixed**
 
-Currently there is a bug that places model in the ground slightly when on a server.
-
-**This will be fixed**
-
-To get around this right now, moving down with playspace mover will help with the offsets. 
+To get around this right now, moving down with playspace mover will help with the offsets.

--- a/index.md
+++ b/index.md
@@ -22,3 +22,4 @@ Lavender is a massive community-driven social sandbox game akin to games such as
  - [What is Unity DOTS?](https://unity.com/dots)
  - [Get Unity Hub](https://unity3d.com/get-unity/download)
  - [Full-body binding](./full-body-binding.md)
+ - [Keyboard shortcuts](./keyboard-shortcuts.md)

--- a/keyboard-shortcuts.md
+++ b/keyboard-shortcuts.md
@@ -1,0 +1,14 @@
+LavenderVR provides a set of keyboard shortcuts available at any time. These are:
+
+ - <kbd>ESC</kbd> opens and closes the tablet
+ - <kbd>caps lock</kbd> toggles between walking and jogging
+ - <kbd>left shift</kbd> engages sprinting, when held down
+ - <kbd>V</kbd> is a **P**ush-**T**o-**T**alk button
+ - <kbd>T</kbd> toggles noclip
+ - <kbd>F3</kbd> opens network debug window
+ - <kbd>F4</kbd> opens picture spawning system
+ - <kbd>F5</kbd> refreshes the UI
+ - <kbd>F6</kbd> opens manual connect window
+ - <kbd>F7</kbd> forces you to respawn
+ - <kbd>F9</kbd> toggles between VR and Desktop modes *(this feature requires SteamVR to be running)*
+ - <kbd>F10</kbd> toggles unscaled movement speed and jump height

--- a/scripting.md
+++ b/scripting.md
@@ -9,6 +9,7 @@ multiple includes is allowed, there will be a gamemode structure to work from.
 [Uploading Content](./uploading-content.md)
 
 Temp export of the api, will be updated more soon
+
 ````LuaAPI
 Core lua api that can be accessed under the global table called "api"
 Exported Type:LuaAPI
@@ -70,3 +71,4 @@ Example:
 ComponentRef
 Safe handle to a Component on a gameobject returned by various api methods
 Exported Type:ComponentRef
+````

--- a/scripting.md
+++ b/scripting.md
@@ -1,7 +1,7 @@
 
 # Scripting
 
-Currently all scripting is done in lua, though text assets inside of your project.
+Currently all scripting is done in lua, through text assets inside of your project.
 multiple includes is allowed, there will be a gamemode structure to work from.
 
 [Code Reference](#)

--- a/server-hosting.md
+++ b/server-hosting.md
@@ -1,12 +1,12 @@
-Run lavender's main game client on a server with one of several command line options to host a dedicated server.
-you can install the game and update it through steamcmd
-the games steamid is 886710
+Run lavender's main game client on a server with one of several command line options to host a dedicated server.  
+You can install the game and update it through steamcmd using appid of `886710`:
 
 ````
 app_install 886710
 app_update 886710
 ````
 
+Starting a server should be easy. Please refer to [command-line flags](./command-line-flags.md) for more information on what these args do.
 ````
 lavender.exe -server -world "d737e06c-39ac-4442-9ffd-1bec7cadb1d7" -nosteam -batchmode -nographics -user "email" -password "password" -logfile "log.txt"
 ````

--- a/uploading-content.md
+++ b/uploading-content.md
@@ -3,26 +3,30 @@
 
 ## Registering
 
-To upload content officially we need to register for an account on [Lavender's Website](https://LavenderVR.com), this can be done by going to [Register New account](https://lavendervr.com/Account/Register)
-Fill out your Email, Username, Password.
-The Email is used to login into the official public galaxy.
-The Username is not unique and can be changed at any time, this is the display name that others see.
-Make sure you use the right email to register as we’ll be using this to link our Steam Account or Other service to verify & validate game ownership with the account.
-Make sure to confirm the email, be sure to check Spam section of your email provider if you have not immediately received an email after registering. 
-If you are having any difficulties registering, you may reach out to us over email at support@takeovergames.com or through our Discord Server at [Discord Invite](https://discord.gg/fWHjNfg)
+To upload content officially we need to register for an account on [Lavender's Website](https://LavenderVR.com), this can be done by going to [Register New account](https://lavendervr.com/Account/Register). Fill out your Email, Username, Password.
 
-## Logging
+Notes:
+ - The Email is used to login into the official public galaxy.
+ - The Username __is not unique__ and can be changed at any time, this is merely the display name that others see.
+ - Make sure you use the right email to register as we’ll be using this to link our Steam Account or Other service to verify & validate game ownership with the account.
+ - Make sure to confirm the email. Be sure to check Spam section of your email provider if you have not immediately received an email after registering. 
+ - If you are having any difficulties registering, you may reach out to us over email at `support@takeovergames.com` or through our [Discord Server](https://discord.gg/fWHjNfg)
 
-Now that we’ve registered and confirmed our email, we can sign in, and start uploading content by going to [Content/Upload](https://lavendervr.com/Content/Upload)
-This is where we’ll be uploading our content, to do this, drag the file onto the Browse button from Explorer or browse to the file, Name our content, decide if our content is going to be Private or Public, give it a Description and select the right content type for it (Avatar, World, Prop, Gamemode), add a Picture that will be shown in-game to others and hit Upload.
-Managing Content
+## Logging in
 
+Now that we’ve registered and confirmed our email, we can sign in, and start uploading content by going to [Content/Upload](https://lavendervr.com/Content/Upload) section.  
+This is where we’ll be uploading our content. To do this, drag the file onto the Browse button from Explorer or browse to the file. Name your content, decide if your content is going to be Private or Public, give it a Description and select the right content type for it (Avatar, World, Prop, or Gamemode), add a preview Picture that will be shown in-game to others, then hit Upload.
+
+
+## Managing Content
+*TBD*
 
 ## Updating Content
 
-To update our content, we first have to go to [My Uploads](https://lavendervr.com/Content/MyUploads)
-Here we’ll find everything we’ve uploaded, we can search through it, we can select the Content Type (All, Avatar, World, Prop, Gamemode) and we can order it by (Date Added, Name, Type).
+To update your content, you first have to go to [My Uploads](https://lavendervr.com/Content/MyUploads) section.  
+Here you’ll find everything you’ve uploaded. You can search through it, filter by the Content Type (All, Avatar, World, Prop, Gamemode), and order it by Date Added, Name, or Type.
 
-Find the content you wish to update and hit Edit, this will bring up the page for it, browse to the updated Asset file and hit Upload. 
-You may also change it to Private or Public and update the Description if required.
-Once it’s done your content will be re-downloaded in-game on the next game restart
+Find the content you wish to update and hit Edit, this will bring up the edit page for it. Browse to the updated Asset file and hit Upload.  
+You may also change it to Private or Public and update the Description, if desired.
+
+Once it’s done your content will be re-downloaded in-game on the next game restart.


### PR DESCRIPTION
If not using paragraphs, actual line breaks have to be preceded by two whitespaces.

````
Line 1.  
Line 2.
````